### PR TITLE
fix(config): update CORS policy to use environment variable for allow…

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -30,7 +30,7 @@ const nextConfig: NextConfig = {
         source: '/api/:path*',
         headers: [
           { key: 'Access-Control-Allow-Credentials', value: 'true' },
-          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Origin', value: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:80' },
           { key: 'Access-Control-Allow-Methods', value: 'GET,DELETE,PATCH,POST,PUT' },
           { key: 'Access-Control-Allow-Headers', value: 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization' },
         ],


### PR DESCRIPTION
…ed origin

This commit modifies the CORS configuration in `next.config.ts` to dynamically set the `Access-Control-Allow-Origin` header based on the `NEXT_PUBLIC_API_URL` environment variable. This change enhances security by ensuring that the allowed origin is configurable, allowing for a more flexible development and deployment setup while maintaining proper access control for cross-origin requests.