### PR TITLE
Fix repo directory name in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ The **AI Growth Operator** is a sophisticated AI agent that automates and optimi
 1. Clone the repository:
    ```
    git clone <repository-url>
-   cd ai-ugc
+   cd ai_growth_operator
    ```
 
 2. Set up the backend (see Backend API section below)
@@ -207,7 +207,7 @@ backend/
 1. Clone the repository:
    ```
    git clone <repository-url>
-   cd ai-ugc
+   cd ai_growth_operator
    ```
 
 2. Set up the Python virtual environment:


### PR DESCRIPTION
## Summary
- correct repo directory from `ai-ugc` to `ai_growth_operator` in setup instructions

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fd77bf0308325a2c0435f0649562e